### PR TITLE
Fix bad argument error when there are multiple IP.

### DIFF
--- a/wsshuttle
+++ b/wsshuttle
@@ -137,7 +137,7 @@ set_xs(){
 }
 
 set_env(){
-    WSL2_IP=$(hostname -I)
+    WSL2_IP=$(hostname -I | cut -d' ' -f1)
 
     WIN_VIFIP=$(ip r s default | cut -d' ' -f3)
     WIN_VIFID=$(arp.exe -a | grep "^I.*: $WIN_VIFIP" | awk '$0=strtonum($4)')


### PR DESCRIPTION
WSL2上で複数のIPアドレスが割り当てられている場合(例えばdocker)、hostname -Iコマンドが複数のIPアドレスを出力してしまい、結果としてroute.exe addコマンドがエラーになってしまいます。
このPullRequestではこの問題を解決します。

### エラーの情報

```
❯ ./wsshuttle -r example-host 192.168.10.100
C:\windows\system32\ROUTE.EXE: bad argument 172.17.0.1
-- snip --
```

私の環境ではhostname -Iが複数のIPアドレスを出力します。

```
❯ hostname -I
172.18.173.203 172.17.0.1
```

IPアドレス一覧です。不要な部分は省略しています。

```
❯ ip a
-- snip --
4: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:15:5d:5a:00:14 brd ff:ff:ff:ff:ff:ff
    inet 172.18.173.203/20 brd 172.18.175.255 scope global eth0
-- snip --
7: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:a6:21:7d:86 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
-- snip --
````